### PR TITLE
Update platform-specific-modules.mdx

### DIFF
--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -15,7 +15,7 @@ You can use the [`Platform`](https://reactnative.dev/docs/platform-specific-code
 
 ```jsx app/_layout.js
 import { Platform } from 'react-native';
-import { Link, Tabs } from 'expo-router';
+import { Link, Tabs, Slot } from 'expo-router';
 
 export default function Layout() {
   if (Platform.OS === 'web') {


### PR DESCRIPTION
# Why

In the _layout.js code example `<Slot />` is used but missing from the import statement

# How

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
